### PR TITLE
Fix code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/api.py
+++ b/api.py
@@ -199,4 +199,5 @@ def get_similarities():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, threaded=True)
+    debug_mode = os.getenv("FLASK_DEBUG", "False").lower() in ["true", "1"]
+    app.run(debug=debug_mode, threaded=True)


### PR DESCRIPTION
Fixes [https://github.com/RLAlpha49/AniSearchModel/security/code-scanning/1](https://github.com/RLAlpha49/AniSearchModel/security/code-scanning/1)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. This can be achieved by using an environment variable to control the debug mode. We will modify the `app.run()` call to check the environment and set the debug mode accordingly.

- Modify the `app.run()` call to use an environment variable to determine whether to run in debug mode.
- Add the necessary import for the `os` module if not already present.
- Ensure that the default behavior is to run with `debug=False` unless explicitly set otherwise.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
