### PR TITLE
Fix code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -369,7 +369,7 @@ def get_anime_similarities():
 
     except ValueError as e:
         logging.error("Validation error: %s", e)
-        return jsonify({"error": str(e)}), 400
+        return jsonify({"error": "Bad Request"}), 400
     except Exception as e:  # pylint: disable=broad-exception-caught
         logging.error("Internal server error: %s", e)
         return jsonify({"error": "Internal server error"}), 500


### PR DESCRIPTION
Fixes [https://github.com/RLAlpha49/AniSearchModel/security/code-scanning/2](https://github.com/RLAlpha49/AniSearchModel/security/code-scanning/2)

To fix the problem, we need to ensure that the error message returned to the user does not contain any sensitive information. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to log the error and return a generic message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
